### PR TITLE
test: add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # confluence-md
 
+[![Test](https://github.com/jackchuka/confluence-md/workflows/Test/badge.svg)](https://github.com/jackchuka/confluence-md/actions)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jackchuka/confluence-md)](https://goreportcard.com/report/github.com/jackchuka/confluence-md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A CLI tool to convert Confluence pages to Markdown format with support for images and page trees.
 
 ## Features

--- a/internal/confluence/client_test.go
+++ b/internal/confluence/client_test.go
@@ -1,0 +1,510 @@
+package confluence
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackchuka/confluence-md/internal/models"
+	"github.com/jackchuka/confluence-md/internal/version"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestNewClient(t *testing.T) {
+	originalVersion := version.Version
+	version.Version = "v1.2.3"
+	t.Cleanup(func() {
+		version.Version = originalVersion
+	})
+
+	tests := []struct {
+		name          string
+		baseURL       string
+		wantBaseURL   string
+		wantUserAgent string
+	}{
+		{
+			name:          "trims trailing slash",
+			baseURL:       "https://example.atlassian.net/",
+			wantBaseURL:   "https://example.atlassian.net",
+			wantUserAgent: "ConfluenceMd/v1.2.3",
+		},
+		{
+			name:          "no trailing slash",
+			baseURL:       "https://example.atlassian.net",
+			wantBaseURL:   "https://example.atlassian.net",
+			wantUserAgent: "ConfluenceMd/v1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(tt.baseURL, "user", "token")
+			if c.baseURL != tt.wantBaseURL {
+				t.Fatalf("baseURL = %s, want %s", c.baseURL, tt.wantBaseURL)
+			}
+			if c.userAgent != tt.wantUserAgent {
+				t.Fatalf("userAgent = %s, want %s", c.userAgent, tt.wantUserAgent)
+			}
+			if got := c.httpClient.Timeout; got != 60*time.Second {
+				t.Fatalf("timeout = %s, want %s", got, 60*time.Second)
+			}
+		})
+	}
+}
+
+func TestClient_GetPage(t *testing.T) {
+	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	apiPage := ConfluenceAPIPage{
+		ID:    "123",
+		Title: "Sample",
+	}
+	apiPage.Type = "page"
+	apiPage.Status = "current"
+	apiPage.Body.Storage.Value = "<p>Hello</p>"
+	apiPage.Body.Storage.Representation = "storage"
+	apiPage.Version.Number = 7
+	apiPage.Version.When = now
+	apiPage.Version.By.AccountID = "abc"
+	apiPage.Version.By.DisplayName = "Updater"
+	apiPage.Version.By.Email = "updater@example.com"
+	apiPage.Space.Key = "SPACE"
+	apiPage.Space.Name = "Space"
+	apiPage.History.CreatedDate = now.Add(-time.Hour)
+	apiPage.History.CreatedBy.AccountID = "def"
+	apiPage.History.CreatedBy.DisplayName = "Creator"
+	apiPage.History.CreatedBy.Email = "creator@example.com"
+	apiPage.Metadata.Labels.Results = []struct {
+		ID     string "json:\"id\""
+		Name   string "json:\"name\""
+		Prefix string "json:\"prefix\""
+	}{{ID: "1", Name: "important"}}
+
+	transportSuccess := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodGet {
+			return nil, fmt.Errorf("unexpected method %s", r.Method)
+		}
+		if user, token, ok := r.BasicAuth(); !ok || user != "user" || token != "token" {
+			return nil, fmt.Errorf("unexpected auth %s %s", user, token)
+		}
+		if got := r.URL.Query().Get("expand"); !strings.Contains(got, "body.storage") {
+			return nil, fmt.Errorf("missing expand parameter: %s", got)
+		}
+		return jsonResponse(t, http.StatusOK, apiPage), nil
+	})
+
+	transportError := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(t, http.StatusNotFound, ConfluenceErrorResponse{Message: "page not found"}), nil
+	})
+
+	tests := []struct {
+		name      string
+		transport roundTripFunc
+		wantErr   string
+	}{
+		{
+			name:      "success",
+			transport: transportSuccess,
+		},
+		{
+			name:      "api error",
+			transport: transportError,
+			wantErr:   "page not found",
+		},
+		{
+			name: "request failure",
+			transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, errors.New("network down")
+			}),
+			wantErr: "network down",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient("https://example.atlassian.net", "user", "token")
+			client.httpClient = &http.Client{Transport: tt.transport}
+
+			page, err := client.GetPage("123")
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				if page != nil {
+					t.Fatalf("expected nil page, got %#v", page)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if page == nil {
+				t.Fatal("expected page, got nil")
+			}
+			if page.ID != "123" || page.Title != "Sample" {
+				t.Fatalf("unexpected page: %#v", page)
+			}
+			if len(page.Metadata.Labels) != 1 || page.Metadata.Labels[0].Name != "important" {
+				t.Fatalf("unexpected labels: %#v", page.Metadata.Labels)
+			}
+		})
+	}
+}
+
+func TestClient_GetChildPages(t *testing.T) {
+	now := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	transportPagination := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if user, token, ok := r.BasicAuth(); !ok || user != "user" || token != "token" {
+			return nil, fmt.Errorf("unexpected auth %s %s", user, token)
+		}
+		start := r.URL.Query().Get("start")
+		if start == "" {
+			start = "0"
+		}
+		switch start {
+		case "0":
+			resp := ConfluenceSearchResult{
+				Results: []ConfluenceAPIPage{
+					{
+						ID:    "1",
+						Title: "Child 1",
+						Space: struct {
+							Key  string "json:\"key\""
+							Name string "json:\"name\""
+						}{Key: "SPACE"},
+						Version: struct {
+							Number int       "json:\"number\""
+							When   time.Time "json:\"when\""
+							By     struct {
+								Type        string "json:\"type\""
+								AccountID   string "json:\"accountId\""
+								DisplayName string "json:\"displayName\""
+								Email       string "json:\"email\""
+							} "json:\"by\""
+						}{Number: 2, When: now},
+						Body: struct {
+							Storage struct {
+								Value          string "json:\"value\""
+								Representation string "json:\"representation\""
+							} "json:\"storage\""
+						}{Storage: struct {
+							Value          string "json:\"value\""
+							Representation string "json:\"representation\""
+						}{Value: "<p>First</p>", Representation: "storage"}},
+						History: struct {
+							CreatedDate time.Time "json:\"createdDate\""
+							CreatedBy   struct {
+								Type        string "json:\"type\""
+								AccountID   string "json:\"accountId\""
+								DisplayName string "json:\"displayName\""
+								Email       string "json:\"email\""
+							} "json:\"createdBy\""
+						}{CreatedDate: now.Add(-time.Hour)},
+					},
+					{
+						ID:    "2",
+						Title: "Child 2",
+					},
+				},
+				Limit: 2,
+			}
+			return jsonResponse(t, http.StatusOK, resp), nil
+		case "2":
+			resp := ConfluenceSearchResult{
+				Results: []ConfluenceAPIPage{{ID: "3", Title: "Child 3"}},
+				Limit:   2,
+			}
+			return jsonResponse(t, http.StatusOK, resp), nil
+		default:
+			return jsonResponse(t, http.StatusOK, ConfluenceSearchResult{}), nil
+		}
+	})
+
+	transportError := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(t, http.StatusBadGateway, ConfluenceErrorResponse{Message: "bad gateway"}), nil
+	})
+
+	tests := []struct {
+		name      string
+		transport roundTripFunc
+		wantLen   int
+		wantErr   string
+	}{
+		{
+			name:      "pagination",
+			transport: transportPagination,
+			wantLen:   3,
+		},
+		{
+			name:      "api error",
+			transport: transportError,
+			wantErr:   "bad gateway",
+		},
+		{
+			name: "request failure",
+			transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, errors.New("boom")
+			}),
+			wantErr: "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient("https://example.atlassian.net", "user", "token")
+			client.httpClient = &http.Client{Transport: tt.transport}
+
+			pages, err := client.GetChildPages("parent")
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				if pages != nil {
+					t.Fatalf("expected nil pages, got %#v", pages)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(pages) != tt.wantLen {
+				t.Fatalf("expected %d pages, got %d", tt.wantLen, len(pages))
+			}
+		})
+	}
+}
+
+func jsonResponse(t *testing.T, status int, payload any) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(data)),
+	}
+}
+
+func TestHandleErrorResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		wantText string
+	}{
+		{
+			name:     "json body",
+			status:   http.StatusNotFound,
+			body:     `{"message":"missing"}`,
+			wantText: "missing",
+		},
+		{
+			name:     "fallback",
+			status:   http.StatusBadGateway,
+			body:     "upstream failure",
+			wantText: "HTTP 502 - upstream failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient("https://example", "user", "token")
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+				Status:     http.StatusText(tt.status),
+			}
+
+			err := c.handleErrorResponse(resp, "op")
+			if err == nil || !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantText, err)
+			}
+		})
+	}
+}
+
+func TestConvertAPIPageToModel(t *testing.T) {
+	created := time.Date(2024, 1, 1, 1, 1, 1, 0, time.UTC)
+	updated := created.Add(time.Hour)
+
+	api := &ConfluenceAPIPage{}
+	api.ID = "123"
+	api.Title = "Title"
+	api.Space.Key = "SPACE"
+	api.Version.Number = 5
+	api.Version.When = updated
+	api.Version.By.AccountID = "acc2"
+	api.Version.By.DisplayName = "Updater"
+	api.Version.By.Email = "updater@example.com"
+	api.Body.Storage.Value = "<p>content</p>"
+	api.Body.Storage.Representation = "storage"
+	api.Metadata.Labels.Results = []struct {
+		ID     string "json:\"id\""
+		Name   string "json:\"name\""
+		Prefix string "json:\"prefix\""
+	}{{ID: "1", Name: "label"}}
+	api.History.CreatedDate = created
+	api.History.CreatedBy.AccountID = "acc1"
+	api.History.CreatedBy.DisplayName = "Creator"
+	api.History.CreatedBy.Email = "creator@example.com"
+
+	model := convertAPIPageToModel(api)
+
+	if model.ID != "123" || model.Title != "Title" {
+		t.Fatalf("unexpected model: %#v", model)
+	}
+	if model.Metadata.Labels[0].Name != "label" {
+		t.Fatalf("expected label name, got %#v", model.Metadata.Labels)
+	}
+	if model.CreatedAt != created || model.UpdatedAt != updated {
+		t.Fatalf("unexpected timestamps: created %s updated %s", model.CreatedAt, model.UpdatedAt)
+	}
+	if model.CreatedBy.DisplayName != "Creator" || model.UpdatedBy.DisplayName != "Updater" {
+		t.Fatalf("unexpected users: %#v %#v", model.CreatedBy, model.UpdatedBy)
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    models.PageURLInfo
+		wantErr string
+	}{
+		{
+			name:  "valid url",
+			input: "https://example.atlassian.net/wiki/spaces/SPACE/pages/12345/Title",
+			want: models.PageURLInfo{
+				BaseURL:  "https://example.atlassian.net",
+				SpaceKey: "SPACE",
+				PageID:   "12345",
+				Title:    "Title",
+			},
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: "URL is empty",
+		},
+		{
+			name:    "invalid",
+			input:   "://bad url",
+			wantErr: "invalid URL",
+		},
+		{
+			name:    "missing id",
+			input:   "https://example.atlassian.net/wiki/spaces/SPACE/pages//Title",
+			wantErr: "could not extract page ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseURL(tt.input)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected info: %#v want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClient_makeRequestSetsHeaders(t *testing.T) {
+	client := NewClient("https://example", "user", "token")
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if ua := r.Header.Get("User-Agent"); !strings.HasPrefix(ua, "ConfluenceMd/") {
+			t.Fatalf("unexpected user agent: %s", ua)
+		}
+		if accept := r.Header.Get("Accept"); accept != "application/json" {
+			t.Fatalf("unexpected accept header: %s", accept)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			t.Fatalf("content-type should be empty, got %s", ct)
+		}
+		if user, token, ok := r.BasicAuth(); !ok || user != "user" || token != "token" {
+			t.Fatalf("unexpected auth: %s %s", user, token)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	})}
+
+	_, err := client.makeRequest(http.MethodGet, "https://example/resource", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify content-type header is set when body is present
+	client.httpClient = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("expected JSON content type, got %s", ct)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("{}")),
+		}, nil
+	})}
+
+	_, err = client.makeRequest(http.MethodPost, "https://example/resource", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHandleErrorResponseReadFailure(t *testing.T) {
+	client := NewClient("https://example", "user", "token")
+	brokenBody := io.NopCloser(io.MultiReader(&failingReader{}))
+	resp := &http.Response{
+		StatusCode: http.StatusTeapot,
+		Body:       brokenBody,
+	}
+
+	err := client.handleErrorResponse(resp, "op")
+	if err == nil || !strings.Contains(err.Error(), "HTTP 418") {
+		t.Fatalf("expected fallback error, got %v", err)
+	}
+}
+
+type failingReader struct{}
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	return 0, errors.New("read error")
+}
+
+func TestParseURLHandlesEncodedTitle(t *testing.T) {
+	info, err := ParseURL("https://example.atlassian.net/wiki/spaces/SPACE/pages/12345/My%20Title")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Title != "My Title" {
+		t.Fatalf("expected decoded title, got %s", info.Title)
+	}
+}

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -1,0 +1,174 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackchuka/confluence-md/internal/models"
+)
+
+func TestConverterConvertPage(t *testing.T) {
+	conv := NewConverter("images")
+
+	page := &models.ConfluencePage{
+		ID:       "123",
+		Title:    "Sample Page",
+		SpaceKey: "SPACE",
+		Version:  1,
+		Content: models.ConfluenceContent{
+			Storage: models.ContentStorage{
+				Value: "<p>Hello World</p><ac:image ri:filename=\"diagram.png\"></ac:image>",
+			},
+		},
+		Metadata: models.ConfluenceMetadata{
+			Labels: []models.Label{{Name: "Label"}},
+		},
+		CreatedBy: models.User{DisplayName: "Author"},
+		UpdatedAt: time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+	page.Content.Storage.Representation = "storage"
+	page.CreatedAt = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	page.UpdatedBy = models.User{DisplayName: "Editor"}
+
+	tests := []struct {
+		name    string
+		page    *models.ConfluencePage
+		wantErr string
+	}{
+		{
+			name: "success",
+			page: page,
+		},
+		{
+			name:    "invalid page",
+			page:    &models.ConfluencePage{Title: "Missing ID", Content: models.ConfluenceContent{Storage: models.ContentStorage{Value: "<p>content</p>"}}, SpaceKey: "SPACE"},
+			wantErr: "page ID cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc, err := conv.ConvertPage(tt.page, "https://example.atlassian.net")
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				if doc != nil {
+					t.Fatalf("expected nil doc, got %#v", doc)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if doc == nil {
+				t.Fatal("expected document, got nil")
+			}
+			if !strings.Contains(doc.Content, "Hello World") {
+				t.Fatalf("expected markdown content, got %q", doc.Content)
+			}
+			if len(doc.Images) != 1 {
+				t.Fatalf("expected one image reference, got %d", len(doc.Images))
+			}
+			img := doc.Images[0]
+			if img.FileName != "diagram.png" {
+				t.Fatalf("unexpected image name %q", img.FileName)
+			}
+			wantURL := "https://example.atlassian.net/wiki/download/attachments/123/diagram.png"
+			if img.OriginalURL != wantURL {
+				t.Fatalf("unexpected original URL %q want %q", img.OriginalURL, wantURL)
+			}
+			if img.LocalPath != "images/diagram.png" {
+				t.Fatalf("unexpected local path %q", img.LocalPath)
+			}
+		})
+	}
+}
+
+func TestConverterPostprocessMarkdown(t *testing.T) {
+	conv := NewConverter("images")
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "collapse blank lines",
+			input: "line1\n\n\nline2",
+			want:  "line1\n\nline2",
+		},
+		{
+			name:  "trim whitespace",
+			input: "  content  \n\n",
+			want:  "content",
+		},
+		{
+			name:  "fix nested list spacing",
+			input: "\n- item\n\n  - nested\n",
+			want:  "- item\n  - nested",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := conv.postprocessMarkdown(tt.input)
+			if got != tt.want {
+				t.Fatalf("postprocessMarkdown(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConverterPreprocessCDATA(t *testing.T) {
+	conv := NewConverter("images")
+	input := "<![CDATA[<tag>&value]]>"
+	got := conv.preprocessCDATA(input)
+	if !strings.Contains(got, "<pre data-cdata='true'>") {
+		t.Fatalf("expected pre block, got %q", got)
+	}
+	if strings.Contains(got, "<![CDATA[") {
+		t.Fatalf("expected cdata markers removed, got %q", got)
+	}
+	if !strings.Contains(got, "&lt;tag&gt;") {
+		t.Fatalf("expected html escaped content, got %q", got)
+	}
+}
+
+func TestExtractorImageReferences(t *testing.T) {
+	conv := NewConverter("assets")
+	html := `<ac:image ri:filename="one.png"></ac:image><ac:image>missing</ac:image><ac:image ri:filename="two space.png"></ac:image>`
+
+	images := conv.extractImageReferences(html, "123", "https://example.atlassian.net")
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(images))
+	}
+
+	if images[0].OriginalURL != "https://example.atlassian.net/wiki/download/attachments/123/one.png" {
+		t.Fatalf("unexpected original url: %q", images[0].OriginalURL)
+	}
+	if images[1].OriginalURL != "https://example.atlassian.net/wiki/download/attachments/123/two+space.png" {
+		t.Fatalf("unexpected encoded url: %q", images[1].OriginalURL)
+	}
+	if images[1].LocalPath != "assets/two space.png" {
+		t.Fatalf("unexpected local path: %q", images[1].LocalPath)
+	}
+}
+
+func TestFixMarkdownLinks(t *testing.T) {
+	input := "See [Page](/wiki/spaces/SPACE/pages/12345/Some-Page) for details"
+	want := "See [Page](confluence://pageId/12345) for details"
+	if got := fixMarkdownLinks(input); got != want {
+		t.Fatalf("fixMarkdownLinks(%q) = %q, want %q", input, got, want)
+	}
+}
+
+func TestFixNestedListSpacing(t *testing.T) {
+	input := "\n- Item\n\n  - Nested\n\n    - Deep"
+	want := "\n- Item\n  - Nested\n    - Deep"
+	if got := fixNestedListSpacing(input); got != want {
+		t.Fatalf("fixNestedListSpacing(%q) = %q, want %q", input, got, want)
+	}
+}

--- a/internal/converter/plugin_test.go
+++ b/internal/converter/plugin_test.go
@@ -1,0 +1,150 @@
+package converter
+
+import (
+	"strings"
+	"testing"
+
+	htmldom "golang.org/x/net/html"
+
+	convpkg "github.com/JohannesKaufmann/html-to-markdown/v2/converter"
+)
+
+func TestCellHasComplexContent(t *testing.T) {
+	plugin := &confluencePlugin{}
+
+	tests := []struct {
+		name string
+		html string
+		want bool
+	}{
+		{
+			name: "simple paragraph",
+			html: `<table><tbody><tr><td><p>Content</p></td></tr></tbody></table>`,
+			want: false,
+		},
+		{
+			name: "multiple paragraphs",
+			html: `<table><tbody><tr><td><p>First</p><p>Second</p></td></tr></tbody></table>`,
+			want: true,
+		},
+		{
+			name: "contains list",
+			html: `<table><tbody><tr><td><ul><li>Item</li></ul></td></tr></tbody></table>`,
+			want: true,
+		},
+		{
+			name: "contains br",
+			html: `<table><tbody><tr><td>Line<br/>Break</td></tr></tbody></table>`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cell := findNode(t, tt.html, "td")
+			got := plugin.cellHasComplexContent(cell)
+			if got != tt.want {
+				t.Fatalf("cellHasComplexContent(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsBrTags(t *testing.T) {
+	plugin := &confluencePlugin{}
+	node := findNode(t, `<p>Line<br/>Break</p>`, "p")
+	if !plugin.containsBrTags(node) {
+		t.Fatalf("expected br detection")
+	}
+	if plugin.containsBrTags(findNode(t, `<p>No break</p>`, "p")) {
+		t.Fatalf("unexpected br detection")
+	}
+}
+
+func TestGetCellHTMLContent(t *testing.T) {
+	plugin := &confluencePlugin{}
+	cell := findNode(t, `<table><tbody><tr><td><p>Text</p><a href="/link">Link</a></td></tr></tbody></table>`, "td")
+	got := plugin.getCellHTMLContent(cell)
+	if !strings.Contains(got, "<p>Text</p>") || !strings.Contains(got, "<a href=\"/link\">Link</a>") {
+		t.Fatalf("unexpected content: %q", got)
+	}
+}
+
+func TestHandleImage(t *testing.T) {
+	plugin := &confluencePlugin{imageFolder: "images"}
+	node := findNode(t, `<ac:image ri:filename="diagram.png"></ac:image>`, "ac:image")
+	var out strings.Builder
+	status := plugin.handleImage(nil, &out, node)
+	if status != convpkg.RenderSuccess {
+		t.Fatalf("expected render success, got %v", status)
+	}
+	if out.String() != "![diagram.png](images%2Fdiagram.png)" {
+		t.Fatalf("unexpected markdown: %q", out.String())
+	}
+}
+
+func TestHandleEmoticon(t *testing.T) {
+	plugin := &confluencePlugin{}
+	node := findNode(t, `<ac:emoticon ac:emoji-fallback="😊"></ac:emoticon>`, "ac:emoticon")
+	var out strings.Builder
+	status := plugin.handleEmoticon(nil, &out, node)
+	if status != convpkg.RenderTryNext {
+		t.Fatalf("expected try next, got %v", status)
+	}
+	if out.String() != "😊 " {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestHandleTocMacro(t *testing.T) {
+	plugin := &confluencePlugin{}
+	node := findNode(t, `<ac:structured-macro ac:name="toc" />`, "ac:structured-macro")
+	result, tryNext := plugin.handleTocMacro(node)
+	if result != "<!-- Table of Contents -->" || !tryNext {
+		t.Fatalf("unexpected result %q tryNext %v", result, tryNext)
+	}
+
+	nodeWithParams := findNode(t, `<ac:structured-macro ac:name="toc"><ac:parameter ac:name="maxLevel">3</ac:parameter></ac:structured-macro>`, "ac:structured-macro")
+	result, tryNext = plugin.handleTocMacro(nodeWithParams)
+	if tryNext {
+		t.Fatalf("expected tryNext false when parameters present")
+	}
+	if result != "<!-- Table of Contents -->" {
+		t.Fatalf("unexpected result %q", result)
+	}
+}
+
+func TestHandleCodeMacro(t *testing.T) {
+	plugin := &confluencePlugin{}
+	node := findNode(t, `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">go</ac:parameter><ac:plain-text-body><!--[CDATA[fmt.Println(&quot;ok&quot;)]]></ac:plain-text-body></ac:structured-macro>`, "ac:structured-macro")
+	result := plugin.handleCodeMacro(node)
+	expected := "```go\nfmt.Println(\"ok\")\n```\n"
+	if result != expected {
+		t.Fatalf("unexpected code block: %q", result)
+	}
+}
+
+func findNode(t *testing.T, markup, tag string) *htmldom.Node {
+	t.Helper()
+	node, err := htmldom.Parse(strings.NewReader(markup))
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	found := searchNode(node, tag)
+	if found == nil {
+		t.Fatalf("failed to find tag %s in markup %s", tag, markup)
+	}
+	return found
+}
+
+func searchNode(n *htmldom.Node, tag string) *htmldom.Node {
+	if n.Type == htmldom.ElementNode && n.Data == tag {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if found := searchNode(c, tag); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/internal/converter/utils_test.go
+++ b/internal/converter/utils_test.go
@@ -1,0 +1,89 @@
+package converter
+
+import "testing"
+
+func TestParseConfluenceImage(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "with filename",
+			html: `<ac:image ri:filename="image.png"></ac:image>`,
+			want: "image.png",
+		},
+		{
+			name: "missing filename",
+			html: `<ac:image></ac:image>`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseConfluenceImage(tt.html); got != tt.want {
+				t.Fatalf("parseConfluenceImage(%q) = %q, want %q", tt.html, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractLanguageParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "found",
+			html: `<ac:parameter ac:name="language">go</ac:parameter>`,
+			want: "go",
+		},
+		{
+			name: "not found",
+			html: `<ac:parameter ac:name="theme">dark</ac:parameter>`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractLanguageParameter(tt.html); got != tt.want {
+				t.Fatalf("extractLanguageParameter(%q) = %q, want %q", tt.html, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractCodeContent(t *testing.T) {
+	tests := []struct {
+		name string
+		html string
+		want string
+	}{
+		{
+			name: "plain text body",
+			html: `<ac:plain-text-body>console.log(&quot;hi&quot;)</ac:plain-text-body>`,
+			want: `console.log("hi")`,
+		},
+		{
+			name: "converted cdata",
+			html: `<ac:plain-text-body><!--[CDATA[fmt.Println(&quot;ok&quot;)]]></ac:plain-text-body>`,
+			want: `fmt.Println("ok")`,
+		},
+		{
+			name: "missing body",
+			html: `<div>no body</div>`,
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractCodeContent(tt.html); got != tt.want {
+				t.Fatalf("extractCodeContent(%q) = %q, want %q", tt.html, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/downloader/downloader_test.go
+++ b/internal/downloader/downloader_test.go
@@ -1,0 +1,117 @@
+package downloader
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jackchuka/confluence-md/internal/models"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestDownloadImages(t *testing.T) {
+	data := bytes.Repeat([]byte("a"), 8)
+
+	doc := &models.MarkdownDocument{
+		Images: []models.ImageRef{{
+			OriginalURL: "https://example.com/image.png",
+			LocalPath:   "assets/image.png",
+			FileName:    "image.png",
+		}},
+	}
+
+	d := NewDownloader("user@example.com", "token")
+	d.maxSize = int64(len(data))
+	d.httpClient = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			user, token, ok := r.BasicAuth()
+			if !ok || user != "user@example.com" || token != "token" {
+				t.Fatalf("unexpected auth: %s %s", user, token)
+			}
+			if r.URL.String() != "https://example.com/image.png" {
+				t.Fatalf("unexpected url: %s", r.URL)
+			}
+			body := io.NopCloser(bytes.NewReader(data))
+			return &http.Response{
+				StatusCode:    http.StatusOK,
+				Body:          body,
+				Header:        http.Header{"Content-Type": []string{"image/png"}},
+				ContentLength: int64(len(data)),
+			}, nil
+		}),
+	}
+
+	dir := t.TempDir()
+	if err := d.DownloadImages(doc, dir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filePath := filepath.Join(dir, "assets", "image.png")
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	if !bytes.Equal(content, data) {
+		t.Fatalf("unexpected file contents: %q", content)
+	}
+	if doc.Images[0].ContentType != "image/png" {
+		t.Fatalf("expected content type saved")
+	}
+}
+
+func TestDownloadImagesHandlesErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport roundTripFunc
+		wantErr   string
+	}{
+		{
+			name: "http error",
+			transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader("boom")),
+					Status:     "500 Internal Server Error",
+				}, nil
+			}),
+			wantErr: "HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &models.MarkdownDocument{
+				Images: []models.ImageRef{{
+					OriginalURL: "https://example.com/image.png",
+					LocalPath:   "assets/image.png",
+					FileName:    "image.png",
+				}},
+			}
+
+			d := NewDownloader("user", "token")
+			d.httpClient = &http.Client{Transport: tt.transport}
+			d.maxSize = 8
+
+			err := d.DownloadImages(doc, t.TempDir())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDownloadImagesSkipsWhenNoImages(t *testing.T) {
+	d := NewDownloader("user", "token")
+	if err := d.DownloadImages(&models.MarkdownDocument{}, t.TempDir()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/models/markdown_test.go
+++ b/internal/models/markdown_test.go
@@ -1,0 +1,81 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMarkdownDocumentWithFrontmatter(t *testing.T) {
+	doc := &MarkdownDocument{
+		Frontmatter: Frontmatter{
+			Title:  "Sample",
+			Author: "Author",
+			Date:   time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC),
+			Labels: []string{"one", "two"},
+			Confluence: ConfluenceRef{
+				PageID:   "123",
+				SpaceKey: "SPACE",
+				Version:  5,
+				URL:      "https://example/wiki/spaces/SPACE/pages/123/Sample",
+			},
+			Custom: map[string]any{"custom": "value"},
+		},
+		Content: "Body",
+	}
+
+	out, err := doc.WithFrontmatter()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectations := []string{
+		"title: \"Sample\"",
+		"author: \"Author\"",
+		"date: \"2024-01-02T03:04:05Z\"",
+		"- \"one\"",
+		"pageId: \"123\"",
+		"custom: value",
+		"Body",
+	}
+
+	for _, expect := range expectations {
+		if !strings.Contains(out, expect) {
+			t.Fatalf("expected output to contain %q, got %q", expect, out)
+		}
+	}
+}
+
+func TestNewMarkdownDocument(t *testing.T) {
+	page := &ConfluencePage{
+		ID:       "123",
+		Title:    "Sample Page",
+		SpaceKey: "SPACE",
+		Version:  2,
+		Content: ConfluenceContent{
+			Storage: ContentStorage{Value: "<p>content</p>"},
+		},
+		Metadata: ConfluenceMetadata{Labels: []Label{{Name: "label"}}},
+		CreatedBy: User{
+			DisplayName: "Author",
+		},
+		UpdatedAt: time.Date(2024, 2, 3, 4, 5, 6, 0, time.UTC),
+	}
+
+	doc, err := NewMarkdownDocument(page, "https://example.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if doc.Frontmatter.Title != "Sample Page" {
+		t.Fatalf("unexpected title: %s", doc.Frontmatter.Title)
+	}
+	if doc.Frontmatter.Author != "Author" {
+		t.Fatalf("unexpected author: %s", doc.Frontmatter.Author)
+	}
+	if doc.Frontmatter.Confluence.URL != "https://example.atlassian.net/wiki/spaces/SPACE/pages/123/Sample%20Page" {
+		t.Fatalf("unexpected URL: %s", doc.Frontmatter.Confluence.URL)
+	}
+	if len(doc.Frontmatter.Labels) != 1 || doc.Frontmatter.Labels[0] != "label" {
+		t.Fatalf("unexpected labels: %#v", doc.Frontmatter.Labels)
+	}
+}

--- a/internal/models/page_test.go
+++ b/internal/models/page_test.go
@@ -1,0 +1,176 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func validPage() *ConfluencePage {
+	return &ConfluencePage{
+		ID:       "123",
+		Title:    "Sample",
+		SpaceKey: "SPACE",
+		Version:  1,
+		Content: ConfluenceContent{
+			Storage: ContentStorage{Value: "<p>content</p>"},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func TestConfluencePageValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ConfluencePage)
+		wantErr string
+	}{
+		{
+			name:    "valid",
+			mutate:  func(*ConfluencePage) {},
+			wantErr: "",
+		},
+		{
+			name: "missing id",
+			mutate: func(p *ConfluencePage) {
+				p.ID = ""
+			},
+			wantErr: "page ID cannot be empty",
+		},
+		{
+			name: "missing title",
+			mutate: func(p *ConfluencePage) {
+				p.Title = ""
+			},
+			wantErr: "page title cannot be empty",
+		},
+		{
+			name: "missing content",
+			mutate: func(p *ConfluencePage) {
+				p.Content.Storage.Value = ""
+			},
+			wantErr: "page content cannot be empty",
+		},
+		{
+			name: "missing space key",
+			mutate: func(p *ConfluencePage) {
+				p.SpaceKey = ""
+			},
+			wantErr: "space key cannot be empty",
+		},
+		{
+			name: "invalid attachment",
+			mutate: func(p *ConfluencePage) {
+				p.Attachments = []ConfluenceAttachment{{}}
+			},
+			wantErr: "invalid attachment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			page := validPage()
+			tt.mutate(page)
+			err := page.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestConfluencePageGetURL(t *testing.T) {
+	page := validPage()
+	url, err := page.GetURL("https://example.atlassian.net")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://example.atlassian.net/wiki/spaces/SPACE/pages/123/Sample"
+	if url != want {
+		t.Fatalf("unexpected url: %s want %s", url, want)
+	}
+}
+
+func TestConfluencePageGetURLInvalidBase(t *testing.T) {
+	page := validPage()
+	if _, err := page.GetURL("://bad"); err == nil {
+		t.Fatal("expected error for invalid base url")
+	}
+}
+
+func TestGetLabelNames(t *testing.T) {
+	page := validPage()
+	page.Metadata.Labels = []Label{{Name: "one"}, {Name: "two"}}
+	got := page.GetLabelNames()
+	if len(got) != 2 || got[0] != "one" || got[1] != "two" {
+		t.Fatalf("unexpected labels: %#v", got)
+	}
+}
+
+func TestConfluenceAttachmentValidate(t *testing.T) {
+	attachment := ConfluenceAttachment{
+		ID:           "1",
+		Title:        "file",
+		MediaType:    "image/png",
+		FileSize:     10,
+		DownloadLink: "https://example/file",
+	}
+	if err := attachment.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*ConfluenceAttachment)
+		wantErr string
+	}{
+		{
+			name:    "missing id",
+			mutate:  func(a *ConfluenceAttachment) { a.ID = "" },
+			wantErr: "attachment ID cannot be empty",
+		},
+		{
+			name:    "missing title",
+			mutate:  func(a *ConfluenceAttachment) { a.Title = "" },
+			wantErr: "attachment title cannot be empty",
+		},
+		{
+			name:    "missing media type",
+			mutate:  func(a *ConfluenceAttachment) { a.MediaType = "" },
+			wantErr: "attachment media type cannot be empty",
+		},
+		{
+			name:    "invalid size",
+			mutate:  func(a *ConfluenceAttachment) { a.FileSize = 0 },
+			wantErr: "attachment file size must be greater than 0",
+		},
+		{
+			name:    "missing link",
+			mutate:  func(a *ConfluenceAttachment) { a.DownloadLink = "" },
+			wantErr: "attachment download link cannot be empty",
+		},
+		{
+			name:    "invalid link",
+			mutate:  func(a *ConfluenceAttachment) { a.DownloadLink = "::" },
+			wantErr: "invalid download link",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := attachment
+			tt.mutate(&a)
+			err := a.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for key components of the project, significantly improving test coverage and reliability. The new tests cover the converter logic, plugin system, utility functions, downloader, and model validation, ensuring that core functionality is well-verified and robust. Additionally, the `README.md` has been updated with project badges for build status, Go report card, and license.

**Testing improvements:**

* Added extensive unit tests for the `converter` package, including page conversion, markdown postprocessing, CDATA handling, image extraction, and markdown link/list fixes.
* Added tests for the `confluencePlugin` in `plugin_test.go`, covering table cell complexity, image and emoticon handling, TOC and code macro processing, and HTML node utilities.
* Added tests for utility functions in `utils_test.go`, such as parsing Confluence images, extracting language parameters, and code content extraction.
* Added tests for the `downloader` package, verifying image download functionality, error handling, and behavior when no images are present.
* Added tests for the `models` package, including markdown document frontmatter generation, Confluence page validation, URL construction, label extraction, and attachment validation. [[1]](diffhunk://#diff-7c92adb3bf4ae94e4a5347f98b3a9ed70dd17c5b2609de16b62b48915ca2abf9R1-R81) [[2]](diffhunk://#diff-fec85f14a10f518f5a3e18ed403a2e4c5c432e960486a3ad01ba779bd2d8fd9fR1-R176)

**Documentation:**

* Updated `README.md` to include badges for CI status, Go report card, and license.