### PR TITLE
feat: add output namer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ confluence-md tree <page-url> --email your-email@example.com --api-token your-ap
 - `--email, -e`: Your Confluence email address (**required**)
 - `--api-token, -t`: Your Confluence API token (**required**)
 - `--output, -o`: Output directory (default: current directory)
+- `--output-name-template`: Go template for the markdown filename (see below)
 - `--download-images`: Download images from Confluence (default: true)
 - `--image-folder`: Folder to save images (default: `assets`)
 - `--include-metadata`: Include page metadata in the Markdown front matter (default: true)
@@ -73,12 +74,35 @@ confluence-md tree <page-url> --email your-email@example.com --api-token your-ap
 # Convert to a specific directory
 confluence-md page <page-url> --email user@example.com --api-token token --output ./docs
 
+# Prefix filenames with the last updated date (YYYY-MM-DD-title.md)
+confluence-md page <page-url> \
+  --email user@example.com \
+  --api-token token \
+  --output-name-template "{{ .Page.UpdatedAt.Format \"2006-01-02\" }}-{{ .SlugTitle }}"
+
 # Convert without downloading images
 confluence-md page <page-url> --email user@example.com --api-token token --download-images=false
 
 # Convert entire page tree
 confluence-md tree <page-url> --email user@example.com --api-token token --output ./wiki
 ```
+
+### Output name templates
+
+The `--output-name-template` flag accepts a Go text/template string. Templates can reference:
+
+- `{{ .Page }}` – the full Confluence page object (e.g. `{{ .Page.UpdatedAt.Format "2006-01-02" }}`)
+  - `{{ .Page.Title }}` – the original page title
+  - `{{ .Page.ID }}` – the Confluence page ID
+  - `{{ .Page.SpaceKey }}` – the Confluence space key
+  - see ConfluencePage struct for more fields
+- `{{ .SlugTitle }}` – the default slugified title (e.g. `sample-page`)
+
+Additionally, you can use the following helper functions:
+
+- `{{ slug <string> }}` – slugifies a string (e.g. `Sample Page` → `sample-page`)
+
+If the rendered filename omits an extension, `.md` is appended automatically.
 
 ## Supported Confluence Elements
 

--- a/cmd/confluence-md/commands/options.go
+++ b/cmd/confluence-md/commands/options.go
@@ -15,10 +15,11 @@ func (a *authOptions) InitFlags(cmd *cobra.Command) {
 }
 
 type commonOptions struct {
-	DownloadImages  bool
-	ImageFolder     string
-	IncludeMetadata bool
-	OutputDir       string
+	DownloadImages     bool
+	ImageFolder        string
+	IncludeMetadata    bool
+	OutputDir          string
+	OutputNameTemplate string
 }
 
 func (c *commonOptions) InitFlags(cmd *cobra.Command) {
@@ -26,4 +27,5 @@ func (c *commonOptions) InitFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&c.ImageFolder, "image-folder", "assets", "Folder for downloaded images")
 	cmd.Flags().BoolVar(&c.IncludeMetadata, "include-metadata", true, "Include YAML frontmatter")
 	cmd.Flags().StringVarP(&c.OutputDir, "output", "o", "./output", "Output directory")
+	cmd.Flags().StringVar(&c.OutputNameTemplate, "output-name-template", "", "Go template for output filename; available data: {{ .Page.* }}, {{ .SlugTitle }}, {{ .LabelNames }}")
 }

--- a/cmd/confluence-md/commands/page.go
+++ b/cmd/confluence-md/commands/page.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/jackchuka/confluence-md/internal/confluence"
+	"github.com/jackchuka/confluence-md/internal/converter"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,8 @@ var pageOpts PageOptions
 type PageOptions struct {
 	authOptions
 	commonOptions
+
+	OutputNamer converter.OutputNamer
 }
 
 func init() {
@@ -62,6 +65,12 @@ func runPage(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid Confluence URL: %w", err)
 	}
+
+	namer, err := buildOutputNamer(pageOpts.OutputNameTemplate)
+	if err != nil {
+		return fmt.Errorf("invalid output name template: %w", err)
+	}
+	pageOpts.OutputNamer = namer
 
 	// Create Confluence client
 	client := confluence.NewClient(pageInfo.BaseURL, pageOpts.Email, pageOpts.APIKey)

--- a/internal/converter/output_namer.go
+++ b/internal/converter/output_namer.go
@@ -1,0 +1,120 @@
+package converter
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/gosimple/slug"
+	confluenceModel "github.com/jackchuka/confluence-md/internal/confluence/model"
+)
+
+// OutputNamer generates a filename for a converted Confluence page.
+type OutputNamer interface {
+	FileName(page *confluenceModel.ConfluencePage) (string, error)
+}
+
+type outputNamerFunc func(*confluenceModel.ConfluencePage) (string, error)
+
+func (f outputNamerFunc) FileName(page *confluenceModel.ConfluencePage) (string, error) {
+	return f(page)
+}
+
+// DefaultOutputNamer returns the built-in filename generator.
+func DefaultOutputNamer() OutputNamer {
+	return outputNamerFunc(defaultFileName)
+}
+
+// GenerateFileName resolves the filename for a page using the provided namer or the default.
+func GenerateFileName(page *confluenceModel.ConfluencePage, namer OutputNamer) (string, error) {
+	if page == nil {
+		return "", fmt.Errorf("page cannot be nil")
+	}
+
+	if namer == nil {
+		namer = DefaultOutputNamer()
+	}
+
+	name, err := namer.FileName(page)
+	if err != nil {
+		return "", err
+	}
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("generated filename is empty")
+	}
+
+	// Normalise to a base filename to avoid introducing directory traversal.
+	name = filepath.Base(name)
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, "\\", "-")
+
+	if name == "." || name == ".." {
+		return "", fmt.Errorf("generated filename %q is invalid", name)
+	}
+
+	if filepath.Ext(name) == "" {
+		name += ".md"
+	}
+
+	return name, nil
+}
+
+func defaultFileName(page *confluenceModel.ConfluencePage) (string, error) {
+	title := strings.TrimSpace(page.Title)
+	slugified := slug.MakeLang(title, "en")
+	if slugified == "" {
+		slugified = "untitled"
+	}
+	return slugified + ".md", nil
+}
+
+var templateFuncMap = template.FuncMap{
+	"slug": func(value string) string {
+		return slug.MakeLang(value, "en")
+	},
+}
+
+// TemplateOutputNamer renders filenames from a text/template string.
+type TemplateOutputNamer struct {
+	tmpl *template.Template
+}
+
+// NewTemplateOutputNamer creates a template-driven output namer.
+func NewTemplateOutputNamer(tmpl string) (OutputNamer, error) {
+	if strings.TrimSpace(tmpl) == "" {
+		return nil, fmt.Errorf("template cannot be empty")
+	}
+
+	parsed, err := template.New("output_name").Funcs(templateFuncMap).Parse(tmpl)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse output name template: %w", err)
+	}
+
+	return &TemplateOutputNamer{tmpl: parsed}, nil
+}
+
+func (n *TemplateOutputNamer) FileName(page *confluenceModel.ConfluencePage) (string, error) {
+	if page == nil {
+		return "", fmt.Errorf("page cannot be nil")
+	}
+
+	data := outputTemplateData{
+		Page:      page,
+		SlugTitle: slug.MakeLang(strings.TrimSpace(page.Title), "en"),
+	}
+
+	var builder strings.Builder
+	if err := n.tmpl.Execute(&builder, data); err != nil {
+		return "", fmt.Errorf("failed to execute output name template: %w", err)
+	}
+
+	return builder.String(), nil
+}
+
+type outputTemplateData struct {
+	Page      *confluenceModel.ConfluencePage
+	SlugTitle string
+}

--- a/internal/converter/output_namer_test.go
+++ b/internal/converter/output_namer_test.go
@@ -1,0 +1,60 @@
+package converter
+
+import (
+	"testing"
+	"time"
+
+	confluenceModel "github.com/jackchuka/confluence-md/internal/confluence/model"
+)
+
+func TestGenerateFileName_Default(t *testing.T) {
+	page := &confluenceModel.ConfluencePage{Title: "Sample Page"}
+
+	name, err := GenerateFileName(page, nil)
+	if err != nil {
+		t.Fatalf("GenerateFileName returned error: %v", err)
+	}
+	if name != "sample-page.md" {
+		t.Fatalf("expected sample-page.md, got %q", name)
+	}
+}
+
+func TestGenerateFileName_Template(t *testing.T) {
+	template := "{{ .Page.UpdatedAt.Format \"2006-01-02\" }}-{{ .SlugTitle }}"
+	namer, err := NewTemplateOutputNamer(template)
+	if err != nil {
+		t.Fatalf("NewTemplateOutputNamer returned error: %v", err)
+	}
+
+	page := &confluenceModel.ConfluencePage{
+		Title:     "Release Notes",
+		UpdatedAt: time.Date(2024, 9, 12, 10, 0, 0, 0, time.UTC),
+	}
+
+	name, err := GenerateFileName(page, namer)
+	if err != nil {
+		t.Fatalf("GenerateFileName returned error: %v", err)
+	}
+
+	if name != "2024-09-12-release-notes.md" {
+		t.Fatalf("expected 2024-09-12-release-notes.md, got %q", name)
+	}
+}
+
+func TestGenerateFileName_TemplateAddsExtension(t *testing.T) {
+	namer, err := NewTemplateOutputNamer("{{ .SlugTitle }}")
+	if err != nil {
+		t.Fatalf("NewTemplateOutputNamer returned error: %v", err)
+	}
+
+	page := &confluenceModel.ConfluencePage{Title: "Docs"}
+
+	name, err := GenerateFileName(page, namer)
+	if err != nil {
+		t.Fatalf("GenerateFileName returned error: %v", err)
+	}
+
+	if name != "docs.md" {
+		t.Fatalf("expected docs.md, got %q", name)
+	}
+}


### PR DESCRIPTION
This pull request introduces a flexible output filename templating system for converted Confluence pages, allowing users to customize Markdown filenames using Go templates. The changes affect both the CLI (`page` and `tree` commands) and the internal conversion logic, and are fully documented in the `README.md`. The implementation includes robust error handling and comprehensive tests.

**Output Filename Customization**

* Added a new `--output-name-template` CLI flag to both the `page` and `tree` commands, enabling users to specify a Go text/template for output filenames (e.g., prefixing with the last updated date). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R77-R106) [[3]](diffhunk://#diff-ccdefe36ff4609bae8f80a17fa082e5f08345d3b8a75e9973473111b393cc73eR22-R30) [[4]](diffhunk://#diff-874a611687fd099cedb4baf7c7cc9a331deb1cfe2d7dd03e153c9833c1890b69R20-R21)

* Implemented the `OutputNamer` interface and supporting logic in `internal/converter/output_namer.go` to generate filenames using either the default slugified title or a user-provided template. Includes helper functions and template data (e.g., `.Page`, `.SlugTitle`).

* Updated the conversion pipeline in both `page` and `tree` commands to use the new output naming logic, including directory creation and error handling. [[1]](diffhunk://#diff-288ade5de2d7f8aacff37fcb32166ca499dd4e19d29c6edd85f9a378cf8864f1L42-R80) [[2]](diffhunk://#diff-874a611687fd099cedb4baf7c7cc9a331deb1cfe2d7dd03e153c9833c1890b69R88-R93) [[3]](diffhunk://#diff-874a611687fd099cedb4baf7c7cc9a331deb1cfe2d7dd03e153c9833c1890b69L320-R342) [[4]](diffhunk://#diff-874a611687fd099cedb4baf7c7cc9a331deb1cfe2d7dd03e153c9833c1890b69L351-R386) [[5]](diffhunk://#diff-6d57601a3737fba9e40db5c3d4b3e13c5429ae498e366f9e58030b197dd45887R41-R42) [[6]](diffhunk://#diff-6d57601a3737fba9e40db5c3d4b3e13c5429ae498e366f9e58030b197dd45887R69-R74)

**Documentation and Testing**

* Expanded the `README.md` with usage examples and a detailed section describing output name templates, available fields, and helper functions.

* Added comprehensive unit tests for output filename generation, covering default and template-driven cases, as well as extension handling.

**Internal Refactoring**

* Refactored option handling and output path generation to support the new filename templating system, and ensured backward compatibility with existing behavior. [[1]](diffhunk://#diff-288ade5de2d7f8aacff37fcb32166ca499dd4e19d29c6edd85f9a378cf8864f1L42-R80) [[2]](diffhunk://#diff-874a611687fd099cedb4baf7c7cc9a331deb1cfe2d7dd03e153c9833c1890b69L351-R386)

These changes provide much greater flexibility for users exporting Confluence content, while maintaining robust defaults and strong test coverage.