### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/confluence-md
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/JohannesKaufmann/html-to-markdown/v2 v2.5.2


### PR DESCRIPTION
## Version Change
- Go 1.26.1 → 1.26.5

## Security Fixes
Go 1.26.5 (2026-07-07) includes security fixes to:
- crypto/tls
- os

## Verification
- Local verification: `go mod tidy` clean
- Tests: `go test ./...` all pass on macOS/arm64